### PR TITLE
Fix pagination bug in Rikishi view

### DIFF
--- a/rikishi/views.py
+++ b/rikishi/views.py
@@ -35,7 +35,7 @@ class CustomPagination(PaginationBase):
         page = pagination.page
         max_per_page = pagination.max_per_page
         total_items = queryset.count()
-        total_page = math.floor(total_items / max_per_page)
+        total_page = max(math.ceil(total_items / max_per_page) - 1, 0)
         next_page = min(page + 1, total_page)
         previous_page = max(page - 1, 0)
         return {


### PR DESCRIPTION
## Summary
- adjust `total_page` calculation to handle exact page divisions

## Testing
- `pre-commit run --files rikishi/views.py`
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684136099c348329810d3bfb71d71831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination logic to ensure the total number of pages is correctly calculated and never negative, resulting in more accurate page navigation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->