### PR TITLE
Fix Hatsu typo

### DIFF
--- a/banzuke/constants.py
+++ b/banzuke/constants.py
@@ -8,7 +8,7 @@ DIVISIONS = [
 ]
 
 BASHO_NAMES = {
-    1: "Hastu",
+    1: "Hatsu",
     3: "Haru",
     5: "Natsu",
     7: "Nagoya",


### PR DESCRIPTION
## Summary
- correct 'Hastu' to 'Hatsu' in basho names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841394c5ab08329bf77d61f1828f380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a spelling error in the tournament name displayed for key 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->