### PR TITLE
Fix infinite loop in get_all_rikishi

### DIFF
--- a/sumoapi/client.py
+++ b/sumoapi/client.py
@@ -13,8 +13,17 @@ class SumoApiClient:
         records = None
         while True:
             endpoint = f"/rikishis?intai=true&limit=1000&skip={skip * 1000}"
-            response = requests.get(f"{BASE_URL}{endpoint}")
-            records = json.loads(response.text)["records"]
+            try:
+                response = requests.get(f"{BASE_URL}{endpoint}")
+                response.raise_for_status()
+                records = json.loads(response.text)["records"]
+            except (
+                requests.RequestException,
+                json.JSONDecodeError,
+                KeyError,
+            ) as e:
+                print(f"Failed to fetch rikishi records: {e}")
+                break
             if not records:
                 break
             all_rikishi.extend(records)

--- a/sumoapi/client.py
+++ b/sumoapi/client.py
@@ -10,12 +10,14 @@ class SumoApiClient:
     def get_all_rikishi(self):
         all_rikishi = []
         skip = 0
-        records = []
-        while records is not None:
-            all_rikishi.extend(records)
+        records = None
+        while True:
             endpoint = f"/rikishis?intai=true&limit=1000&skip={skip * 1000}"
             response = requests.get(f"{BASE_URL}{endpoint}")
             records = json.loads(response.text)["records"]
+            if not records:
+                break
+            all_rikishi.extend(records)
             skip += 1
         return all_rikishi
 


### PR DESCRIPTION
## Summary
- ensure `SumoApiClient.get_all_rikishi` stops when no records are returned
- add ruff checks

## Testing
- `ruff check sumoapi/client.py`
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684139db20748329b51b9043dd74d66c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading all rikishi records, ensuring more consistent and complete data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->